### PR TITLE
Add an env variable to skip migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ A Dockerfile that we use to deploy stuff to Heroku with.
 ### Configuration
 
 Expose heroku credentials to the container via: `HEROKU_LOGIN` and `HEROKU_API_KEY` variables (set in CircleCI's UI or `config.yml`)
+
+`deploy.sh` does a heroku push and runs migrations by default. Migrations can be skipped by setting `HEROKU_SKIP_DB_MIGRATE` to any value.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,5 +13,13 @@ if [[ -z $APP_NAME ]]; then
 fi
 
 git push -f "git@heroku.com:$APP_NAME.git" "$CIRCLE_SHA1:master"
-heroku run rake db:migrate --app "$APP_NAME" --exit-code
+
+set +u
+if [[ -z $HEROKU_SKIP_DB_MIGRATE ]]; then
+  heroku run rake db:migrate --app "$APP_NAME" --exit-code
+else
+  echo "skipping 'db:migrate' with HEROKU_SKIP_DB_MIGRATE..."
+fi
+set -u
+
 source /scripts/restart.sh "$APP_NAME" "$SLEEP"


### PR DESCRIPTION
db:migrate doesn't work without a db 🤔